### PR TITLE
Updated to work with current Hoogle results

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Original plugin by [Sawny](https://github.com/s4wny/)
 
 ## Support
 
-If there are any problems or you have suggestions, [open an issue](https://github.com/s4wny/HoogleSearch/issues).
+If there are any problems or you have suggestions, [open an issue](https://github.com/pennychase/HoogleSearch/issues).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,37 @@
-Hoogle search
+Hoogle Search
 ===============
 
-[Hoogle](https://www.haskell.org/hoogle/) search integrated into sublime text.
+[Hoogle](https://hoogle.haskell.org/), the Haskell API search engine, integrated into Sublime Text.
+
+
+## Installation
+
+Install using [Package Control](http://wbond.net/sublime_packages/package_control):
+
+1. Run `Package Control: Install Package` command, find and install `Hoogle Search` plugin.
+
 
 ## Usage
 
-![How to](https://raw.githubusercontent.com/s4wny/HoogleSearch/master/howto.gif "How to")
-
-1. Press `ctrl+shift+p` to bring up the command palette.
+1. Press `ctrl/cmd+shift+p` to bring up the command palette.
 2. Enter `hoogle search`.
 3. Enter a hoogle search query
 4. Choose the function you want to know more about
 5. Press enter and the full docs for that function will open in your browser
 
 
-## TODO
+## Screenshots
 
-See the [issues](https://github.com/s4wny/HoogleSearch/issues).
+![How to](https://raw.githubusercontent.com/s4wny/HoogleSearch/master/howto.gif "How to")
+
+
+## Credits
+
+Currently maintained by [Penny Chase](https://github.com/pennychase)
+
+Original plugin by [Sawny](https://github.com/s4wny/)
+
+
+## Support
+
+If there are any problems or you have suggestions, [open an issue](https://github.com/s4wny/HoogleSearch/issues).

--- a/hoogle_search.py
+++ b/hoogle_search.py
@@ -2,10 +2,13 @@
 
 import sublime, sublime_plugin, webbrowser
 import urllib.request, json
+from html.parser import HTMLParser
 import pprint as pp
 
 # Global varz
 results = [];
+
+
 
 class HoogleSearchCommand(sublime_plugin.WindowCommand):
 	def run(self):
@@ -17,15 +20,17 @@ def search(inp):
 	query   = urllib.parse.quote_plus(inp)
 	url     = "https://www.haskell.org/hoogle/?hoogle="+ query +"&mode=json"
 	data    = urllib.request.urlopen(url).read().decode()
-	data 	= json.loads(data)
-	results = data['results']
+	results = json.loads(data)
+	# results = data['results']
 
 
 	formatedResult = []
 
 	if results:
 		for result in results:
-			formatedResult.append(result['self'])
+			formatted = format(result)
+			if formatted != '':
+				formatedResult.append(formatted)
 	else:
 		formatedResult.append("No results")
 
@@ -34,4 +39,38 @@ def search(inp):
 
 def on_done(index):
 	if index != -1:
-		webbrowser.open(results[index]['location'], 2)
+		webbrowser.open(results[index]['url'], 2)
+
+
+def format (result):
+	if result.get('module') == None:
+		return ''
+	else:
+		modname = result.get('module').get('name')
+		if modname == None:
+			return ''
+	if result.get('item') == None:
+		return ''
+	else:
+		res = result['item'].split('::')
+		name = removeHtml(res[0])
+		if len (res) == 1:
+			ret = modname + ' ' + name
+		else:
+			ret = modname + ' ' + name + '::' + res[1]
+	return (HTMLParser().unescape (ret))
+
+def removeHtml (str):
+	result = ''
+	inHtml = False
+	for c in str:
+		if c == '<':
+			inHtml = True
+		elif c == '>':
+			inHtml = False
+		else:
+			if not inHtml:
+				result = result + c
+	return (result)
+
+

--- a/hoogle_search.py
+++ b/hoogle_search.py
@@ -9,7 +9,6 @@ import pprint as pp
 results = [];
 
 
-
 class HoogleSearchCommand(sublime_plugin.WindowCommand):
 	def run(self):
 		self.window.show_input_panel("Hoogle Query", "", search, None, None)
@@ -21,7 +20,6 @@ def search(inp):
 	url     = "https://www.haskell.org/hoogle/?hoogle="+ query +"&mode=json"
 	data    = urllib.request.urlopen(url).read().decode()
 	results = json.loads(data)
-	# results = data['results']
 
 
 	formatedResult = []
@@ -41,25 +39,30 @@ def on_done(index):
 	if index != -1:
 		webbrowser.open(results[index]['url'], 2)
 
-
+# Each Hoogle result is dictionary with the keys: docs, item, module, package, type, and url.
+# To make the results look the hoogle application, create a string with module name and type signature.
+# The module name is in the module dictionary and the type signature is the item string (the function name
+# may be embedded in html tags). Some entries may be missing some of these elements, and we skip them.
 def format (result):
 	if result.get('module') == None:
 		return ''
 	else:
-		modname = result.get('module').get('name')
+		modname = result.get('module').get('name') # get the module name if it exists
 		if modname == None:
 			return ''
 	if result.get('item') == None:
 		return ''
 	else:
-		res = result['item'].split('::')
+		res = result['item'].split('::')  # split type signature into name and type
 		name = removeHtml(res[0])
-		if len (res) == 1:
+		if len (res) == 1:                # the type might not be included in the entry
 			ret = modname + ' ' + name
 		else:
 			ret = modname + ' ' + name + '::' + res[1]
-	return (HTMLParser().unescape (ret))
+	return (HTMLParser().unescape (ret))   # decode html entities
 
+# Remove html tags by skipping over anything between < and >. There seems to be variation in the tags used
+# in Hoogle entries, so this approach removes everything that isn't part of the item's name.
 def removeHtml (str):
 	result = ''
 	inHtml = False

--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,0 +1,1 @@
+{"version": "1.1.0", "dependencies": [], "platforms": ["*"], "description": "Hoogle Search (haskell documentation) for sublime text 3", "sublime_text": ">=3000", "url": "https://github.com/s4wny/HoogleSearch"}

--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,1 +1,0 @@
-{"version": "1.1.0", "dependencies": [], "platforms": ["*"], "description": "Hoogle Search (haskell documentation) for sublime text 3", "sublime_text": ">=3000", "url": "https://github.com/s4wny/HoogleSearch"}


### PR DESCRIPTION
The Hoogle results format seems to have changed since the package was developed and searches within SublimeText were failing. I modified hoogle_search.py to work with the current results.